### PR TITLE
Feature/dev/codemode v2

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -20,7 +20,7 @@ export default function AppRouter() {
       <Route path="/signup" element={<SignupFormView />} />
       <Route path="/logout" element={<LogoutView />} />
       <Route path="/code" element={<CodeModeView />} />
-
+      <Route path="/code/:id" element={<CodeModeView />} />
     </Routes>
   );
 }

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -60,7 +60,7 @@ export default function CodeMode({ currentDoc, }: {
 
         async function saveCode() {
             const inputs = {
-                title: title || "Testtitel som bara fungerar en gång",
+                title: title || "No titel",
                 content: editorContent,
                 id: currentDoc?.id || "",
                 type: "code"

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import { io } from "socket.io-client";
 import Editor from "@monaco-editor/react";
 import documents from "../models/documents.ts";
+import executeJs from "../models/execjs.ts";
 
 const SERVER_URL = "http://localhost:3000";
 
@@ -49,8 +50,8 @@ export default function CodeMode({ currentDoc, }: {
             setTitle(value);
         }
 
-        function runCode() {
-            const result = 'Api-call return result from model is here for me :)'
+        async function runCode() {
+            const result = await executeJs.execCode(editorContent)
             setCodeOutput(result)
             console.log('Code successfully sent into space somewhere')
         }

--- a/src/components/DocumentsList.tsx
+++ b/src/components/DocumentsList.tsx
@@ -9,12 +9,17 @@ export default function DocumentsList() {
         <div className="documentsList">
         
         <h3>Mina egna dokument:</h3>
-        {docs.owner.map((doc: { _id: string; title: string; content: string; created_at: string }) => (
-            <p key={doc._id}> <Link to={`/${doc._id}`} state={{ doc }}>{doc.title}</Link></p>
+        {docs.owner.map((doc: { _id: string; title: string; content: string; created_at: string; type: string }) => (
+            <p key={doc._id}>
+                <Link to={doc.type === 'code' ? `/code/${doc._id}` :`/${doc._id}`}
+                state={{ doc }}>{doc.title}</Link>
+            </p>
         ))}
         <h3>Dokument skapad av andra jag får uppdatera:</h3>
-        {docs.editor.map((doc: { _id: string; title: string; content: string; created_at: string }) => (
-            <p key={doc._id}> <Link to={`/${doc._id}`} state={{ doc }}>{doc.title}</Link></p>
+        {docs.editor.map((doc: { _id: string; title: string; content: string; created_at: string; type: string }) => (
+            <p key={doc._id}>
+                <Link to={doc.type === 'code' ? `/code/${doc._id}` : `/${doc._id}`}
+                state={{ doc }}>{doc.title}</Link></p>
         ))}
     </div>
     );

--- a/src/models/execjs.ts
+++ b/src/models/execjs.ts
@@ -1,0 +1,18 @@
+const executeJs = {
+
+    execCode: async function execCode(codeSnippet) {
+        const response = await fetch("https://execjs.emilfolino.se/code", {
+            body: JSON.stringify({code: btoa(codeSnippet)}),
+            headers: {
+                'content-type': 'application/json'
+            },
+            method: 'POST'
+    });
+        const result = await response.json();
+        const decodedOutput = atob(result.data)
+        console.log(decodedOutput)
+        return decodedOutput
+    }
+};
+
+export default executeJs;


### PR DESCRIPTION
Added api model for execjs api with returning results in <pre> container
Added type-based routing so documents lands directly into code-editor  or text editor based on their type in the database.
Updated paths for /code so it supports getting documents with :id